### PR TITLE
Fix heading tag

### DIFF
--- a/content/_includes/post.njk
+++ b/content/_includes/post.njk
@@ -3,7 +3,7 @@ layout: base.njk
 ---
 
 <div class="content post border-solid border-b-1 border-gray-700 pb-6">
-  	<h1>{{ title }}</h2>
+  	<h2>{{ title }}</h2>
   	<div class="mb-12 flex text-sm font-light dark:font-extralight">
 		<div class="flex">
         	<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600.112 600.111" class="h-5 w-4 mr-2">


### PR DESCRIPTION
Fixed to fully use `<h2></h2>`. Previously used to open `<h1>` and then close with `</h2>`.