### PR TITLE
Use <h1></h1> instead of <h2></h2>

### DIFF
--- a/content/_includes/post.njk
+++ b/content/_includes/post.njk
@@ -3,7 +3,7 @@ layout: base.njk
 ---
 
 <div class="content post border-solid border-b-1 border-gray-700 pb-6">
-  	<h2>{{ title }}</h2>
+  	<h1>{{ title }}</h1>
   	<div class="mb-12 flex text-sm font-light dark:font-extralight">
 		<div class="flex">
         	<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600.112 600.111" class="h-5 w-4 mr-2">


### PR DESCRIPTION
Yikes! I just realized that this supposedly minor change (#61) breaks the automatic scrolling in the `right-area`.
```javascript
const removeActive = (link) => menu[link].classList.remove("active");
```
I suggest to change `<h2></h2>` to `<h1></h1>`. I thought there was already a `<h1></h1>` tag on the site, so I previously chose `<h2>`. 

Sorry!