### PR TITLE
fix: add print css

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -469,3 +469,41 @@ div.code-toolbar > .toolbar span {
     box-shadow: unset;
     border-radius: unset;
 }
+
+@media print {
+    #sidebar #sidebar-contents {
+        display: none;
+    }
+    
+    #right-area #top-bar {
+        display: none;
+    }
+    
+    .grid {
+        display: block;
+    }
+    
+    #scroll {
+        visibility: hidden;
+    }
+    
+    aside {
+        display: none;
+    }
+    
+    #search-container {
+        display: none;
+    }
+    
+    main .content .social {
+        display: none;
+    }
+    
+    main .content.border-b-1, main .block.border-b-1 {
+        border-bottom-width: 0px;
+    }
+    
+    main .content .additions {
+        display: none;
+    }
+}


### PR DESCRIPTION
With the current css, printing posts will result in an inner scrollbar and other undesirable elements, and also prevents printing the whole page (it would only print the current viewport instead of the whole page). 

This hides all the undesirable elements: 
- sidebar
- toc
- top-bar
- borders
- scroller arrow
- social links
- older/newer post links